### PR TITLE
Introducing winston logger 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/History.md
+++ b/History.md
@@ -1,4 +1,8 @@
-1.0.0 - January 24, 2013
+2.0.0 - January 05, 2015
+-------------------------
+- breaking change: winston logger exposes `WinstonLogger` class.
+
+1.0.1 - January 24, 2013
 -------------------------
 - console: handle exceptions
 

--- a/Readme.md
+++ b/Readme.md
@@ -50,45 +50,46 @@ And `production` options:
 
 ###### Usage
 
-    Give winston logger the wanted winston module
+Give winston logger the wanted winston module
 
-    ```js
-    var winstonLogger = require('winston-logger')(require('winston'));
-    // verbose way: winston is unused
-    var winston = require('winston'),
-        winstonLogger = require('winston-logger')(winston)
-    // shortest way: winston will be loaded by winston-logger (will load the version in winston-logger's package json)
-    var winstonLogger = require('winston-logger')();
-    ```
+```js
+var winstonLogger = require('winston-logger')(require('winston'));
+// verbose way: winston is unused
+var winston = require('winston'),
+    winstonLogger = require('winston-logger')(winston)
+// shortest way: winston will be loaded by winston-logger
+// will load the version in winston-logger's package json
+var winstonLogger = require('winston-logger')();
+```
 
-    Configure colors and labels with the 'options' parameter
+Configure colors and labels with the 'options' parameter
 
-    ```js
-    var options = {
-        colors: {
-                  silly    : 'magenta',
-                  verbose  : 'blue',
-                  debug    : 'cyan',
-                  info     : 'green',
-                  warn     : 'yellow',
-                  error    : 'red',
-                  critical : 'red',
-                  fatal    : 'red'
-                },
-        labels: {
-                  silly: 0,
-                  verbose: 1,
-                  debug: 2,
-                  info: 3,
-                  warn: 4,
-                  error: 5,
-                  critical: 6,
-                  fatal: 7
-                }
-    };
+```js
+var options = {
+    colors: {
+              silly    : 'magenta',
+              verbose  : 'blue',
+              debug    : 'cyan',
+              info     : 'green',
+              warn     : 'yellow',
+              error    : 'red',
+              critical : 'red',
+              fatal    : 'red'
+            },
+    labels: {
+              silly: 0,
+              verbose: 1,
+              debug: 2,
+              info: 3,
+              warn: 4,
+              error: 5,
+              critical: 6,
+              fatal: 7
+            }
+};
 
-    var winstonLogger = require('winston-logger')(require('winston'), options);
-    ```
+var winstonLogger = require('winston-logger')(require('winston'), options);
+```
 
 
 #### WinstonLogger.create(options)

--- a/Readme.md
+++ b/Readme.md
@@ -5,9 +5,9 @@
 ## Example
 
 ```js
-var Logger = require('winston-logger');
+var winstonLogger = require('winston-logger')();
 
-var logger = Logger({ console: true });
+var logger = winstonLogger.create({ console: true });
 logger.info(..)
 ```
 
@@ -44,7 +44,54 @@ And `production` options:
 
 ## API
 
-#### Logger(options)
+#### WinstonLogger(winston, options)
+
+    Create an instance of WinstonLogger with the given winston module and the given options
+
+###### Usage
+
+    Give winston logger the wanted winston module
+
+    ```js
+    var winstonLogger = require('winston-logger')(require('winston'));
+    // verbose way: winston is unused
+    var winston = require('winston'),
+        winstonLogger = require('winston-logger')(winston)
+    // shortest way: winston will be loaded by winston-logger (will load the version in winston-logger's package json)
+    var winstonLogger = require('winston-logger')();
+    ```
+
+    Configure colors and labels with the 'options' parameter
+
+    ```js
+    var options = {
+        colors: {
+                  silly    : 'magenta',
+                  verbose  : 'blue',
+                  debug    : 'cyan',
+                  info     : 'green',
+                  warn     : 'yellow',
+                  error    : 'red',
+                  critical : 'red',
+                  fatal    : 'red'
+                },
+        labels: {
+                  silly: 0,
+                  verbose: 1,
+                  debug: 2,
+                  info: 3,
+                  warn: 4,
+                  error: 5,
+                  critical: 6,
+                  fatal: 7
+                }
+    };
+
+    var winstonLogger = require('winston-logger')(require('winston'), options);
+    ```
+
+
+#### WinstonLogger.create(options)
 
     Create a winston logger with provided transports in the options.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,41 @@
-
 var defaults = require('defaults');
 var transports = require('./transports');
 var winston = require('winston');
 
 /**
- * Expose `create`.
+ *
+ * WinstonLogger class to create loggers
+ *
+ * @param winston
+ * @param options
+ * @constructor
  */
+function WinstonLogger(winston, options){
+  this.winston = winston || require('winston');
+  this.options = options || {};
 
-module.exports = create;
+  this.options.colors = defaults(this.options.colors, {
+      silly    : 'magenta',
+      verbose  : 'blue',
+      debug    : 'cyan',
+      info     : 'green',
+      warn     : 'yellow',
+      error    : 'red',
+      critical : 'red',
+      fatal    : 'red'
+  });
 
+  this.options.levels = defaults(this.options.levels, {
+      silly: 0,
+      verbose: 1,
+      debug: 2,
+      info: 3,
+      warn: 4,
+      error: 5,
+      critical: 6,
+      fatal: 7
+  });
+}
 
 /**
  * Create a logger.
@@ -17,11 +44,11 @@ module.exports = create;
  * @return {Logger}
  */
 
-function create (options) {
+WinstonLogger.prototype.create = function (options) {
   if (!options) throw new Error('Winston logger must be initialized with options.');
 
-  setColors(); // set global winston colors
-  setLevels(winston); // set global winston levels
+  this.winston.addColors(this.options.colors);// set global winston colors
+  this.winston.setLevels(this.options.levels); // set global winston levels
 
   var enabled = [];
   Object.keys(options).forEach(function (key) {
@@ -39,53 +66,14 @@ function create (options) {
   });
 
   var logger = new (winston.Logger)({ transports: enabled });
-  setLevels(logger);
+  logger.setLevels(this.options.levels);
   return logger;
-}
-
-
-/**
- * Set Winston levels.
- *
- * @param {Logger} logger
- * @param {Object} levels
- */
-
-function setLevels (logger, levels) {
-
-  levels = defaults(levels, {
-    silly: 0,
-    verbose: 1,
-    debug: 2,
-    info: 3,
-    warn: 4,
-    error: 5,
-    critical: 6,
-    fatal: 7
-  });
-
-  logger.setLevels(levels);
-}
-
+};
 
 /**
- * Set global Winston levels.
- *
- * @param {Object} colors
+ * Expose `WinstonLogger` class.
  */
 
-function setColors (colors) {
-
-  colors = defaults(colors, {
-    silly    : 'magenta',
-    verbose  : 'blue',
-    debug    : 'cyan',
-    info     : 'green',
-    warn     : 'yellow',
-    error    : 'red',
-    critical : 'red',
-    fatal    : 'red'
-  });
-
-  winston.addColors(colors);
-}
+module.exports = function(winston, options){
+    return new WinstonLogger(winston, options);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ WinstonLogger.prototype.create = function (options) {
 };
 
 /**
- * Expose `WinstonLogger` class.
+ * Expose an `WinstonLogger` instance.
  */
 
 module.exports = function(winston, options){

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.1",
   "main": "./lib/index",
   "dependencies": {
-    "winston-papertrail": "~0.1.4",
-    "winston": "~0.7.2",
+    "winston-papertrail": "~1.0.1",
+    "winston": "~0.8.3",
     "defaults": "~1.0.0",
-    "winston-mail": "~0.2.7"
+    "winston-mail": "~0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "winston-logger",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "main": "./lib/index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/winston-logger.git"
+  },
   "dependencies": {
     "winston-papertrail": "~1.0.1",
     "winston": "~0.8.3",


### PR DESCRIPTION
Hi,
I added the option to give the module a winston object to use instead of relaying on the version in the package json, discussed here #2

Because it was a breaking change I had to change the version number to 2.0.0 according to [Semantic Versioning](http://semver.org/)

Hope you like the changes :+1: 
